### PR TITLE
Image URI parser: Invalid uris do not crash parser

### DIFF
--- a/lib/image_info/image.rb
+++ b/lib/image_info/image.rb
@@ -7,7 +7,7 @@ module ImageInfo
     attr_accessor :width, :height, :type
 
     def initialize(uri)
-      @uri = ::URI.parse(uri.to_s)
+      @uri = ::URI.parse(::URI.encode(uri.to_s))
     end
 
     def size

--- a/spec/image_info/image_spec.rb
+++ b/spec/image_info/image_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe ImageInfo::Image do
@@ -21,6 +22,20 @@ describe ImageInfo::Image do
       end
 
       it { expect(instance.size).to eq([1, 2]) }
+
+    end
+
+  end
+
+  describe 'parsing invalid uri does not crash' do
+
+    context 'trys to fix invalid characters' do
+
+      let(:uri) { 'http://karrierebibel.de/wp-content/uploads/2015/03/7_Todsünden_der_Jobsuche_sauer_wütend.jpg' }
+
+      it { expect(instance.valid?).to eq(true) }
+
+      it { expect(instance.uri).to eq(URI.parse 'http://karrierebibel.de/wp-content/uploads/2015/03/7_Tods%C3%BCnden_der_Jobsuche_sauer_w%C3%BCtend.jpg') }
 
     end
 


### PR DESCRIPTION
Using the link-thumbnail Gem, I had problems to process pages, where the page author did not correctly escape their image links, e.g.:

```
Exception: URI::InvalidURIError: bad URI(is not URI?): http://karrierebibel.de/wp-content/uploads/2015/03/7_Todsünden_der_Jobsuche_sauer_wütend.jpg
--
0: /home/local/PDC01/swi/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/uri/common.rb:176:in `split'
1: /home/local/PDC01/swi/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/uri/common.rb:211:in `parse'
2: /home/local/PDC01/swi/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/uri/common.rb:747:in `parse'
3: /home/local/PDC01/swi/.rvm/gems/ruby-2.1.2/gems/image_info-1.1.0/lib/image_info/image.rb:10:in `initialize'
```

I've added a rescue clause + I noticed I could try to fix that encoding by escaping all uri parts which are not yet encoded. 
