### PR TITLE
Download just enough data

### DIFF
--- a/lib/image_info/null_parser.rb
+++ b/lib/image_info/null_parser.rb
@@ -1,0 +1,12 @@
+module ImageInfo
+  class NullParser
+    def width
+    end
+
+    def height
+    end
+
+    def format
+    end
+  end
+end

--- a/lib/image_info/parser.rb
+++ b/lib/image_info/parser.rb
@@ -11,7 +11,7 @@ module ImageInfo
     end
 
     def call
-      return unless parser
+      return false unless parser
       set_image_size
       set_image_type
     end

--- a/lib/image_info/parser.rb
+++ b/lib/image_info/parser.rb
@@ -3,7 +3,7 @@ require 'image_size'
 module ImageInfo
   class Parser
 
-    attr_reader :image
+    attr_reader :image, :data
 
     def initialize(image, data)
       @image = image
@@ -11,7 +11,6 @@ module ImageInfo
     end
 
     def call
-      return false unless parser
       set_image_size
       set_image_type
     end
@@ -30,8 +29,9 @@ module ImageInfo
     private
     
     def parser
-      @parser ||= ::ImageSize.new(@data) 
+      @parser ||= ::ImageSize.new(data)
     rescue ImageSize::FormatError
+      @parser ||= ::ImageInfo::NullParser.new
     end
   end
 end

--- a/lib/image_info/parser.rb
+++ b/lib/image_info/parser.rb
@@ -3,15 +3,15 @@ require 'image_size'
 module ImageInfo
   class Parser
 
-    attr_reader :image, :bytes, :parser
+    attr_reader :image
 
     def initialize(image, data)
-      @image  = image
-      @bytes  = data.bytes
-      @parser = ::ImageSize.new(data)
+      @image = image
+      @data = data
     end
 
     def call
+      return unless parser
       set_image_size
       set_image_type
     end
@@ -26,6 +26,12 @@ module ImageInfo
     def set_image_type
       image.type = parser.format
     end
-
+    
+    private
+    
+    def parser
+      @parser ||= ::ImageSize.new(@data) 
+    rescue ImageSize::FormatError
+    end
   end
 end

--- a/lib/image_info/processor.rb
+++ b/lib/image_info/processor.rb
@@ -2,6 +2,7 @@ require 'typhoeus'
 
 require 'image_info/image'
 require 'image_info/parser'
+require 'image_info/null_parser'
 require 'image_info/request_handler'
 
 module ImageInfo

--- a/lib/image_info/request_handler.rb
+++ b/lib/image_info/request_handler.rb
@@ -1,14 +1,14 @@
 module ImageInfo
   class RequestHandler
 
-    attr_reader :image
+    attr_reader :image, :buffer
 
     def initialize(image)
       @image = image
+      @buffer = StringIO.new
     end
 
     def build
-      buffer = StringIO.new
       ::Typhoeus::Request.new(image.uri.to_s, followlocation: true, accept_encoding: :gzip).tap do |request|
         request.on_body do |chunk|
           buffer.write(chunk)
@@ -22,6 +22,5 @@ module ImageInfo
     def found_image_info?(chunk)
       ::ImageInfo::Parser.new(image, chunk).call
     end
-
   end
 end

--- a/lib/image_info/request_handler.rb
+++ b/lib/image_info/request_handler.rb
@@ -8,15 +8,19 @@ module ImageInfo
     end
 
     def build
+      buffer = StringIO.new
       ::Typhoeus::Request.new(image.uri.to_s, followlocation: true, accept_encoding: :gzip).tap do |request|
-        request.on_complete { |response| on_complete(response) }
+        request.on_body do |chunk|
+          buffer.write(chunk)
+          :abort if found_image_info?(buffer)
+        end
       end
     end
 
     private
 
-    def on_complete(response)
-      ::ImageInfo::Parser.new(image, response.body).call if response.success?
+    def found_image_info?(chunk)
+      ::ImageInfo::Parser.new(image, chunk).call
     end
 
   end

--- a/spec/image_info/parser_spec.rb
+++ b/spec/image_info/parser_spec.rb
@@ -55,6 +55,25 @@ describe ImageInfo::Parser do
 
     end
 
+    context 'partial image with not enough data' do
+
+      let(:data) { File.open(File.expand_path('../../fixtures/upload_bird.jpg', __FILE__)).read(50) }
+
+      it { expect { call }.not_to change { image.type } }
+      it { expect { call }.not_to change { image.size } }
+
+    end
+    
+    
+    context 'partial image with enough data' do
+
+      let(:data) { File.open(File.expand_path('../../fixtures/upload_bird.jpg', __FILE__)).read(400) }
+
+      it { expect { call }.to change { image.type }.to eq(:jpeg) }
+      it { expect { call }.to change { image.size }.to eq([775, 525]) }
+
+    end
+
   end
 
 end

--- a/spec/image_info/parser_spec.rb
+++ b/spec/image_info/parser_spec.rb
@@ -61,9 +61,9 @@ describe ImageInfo::Parser do
 
       it { expect { call }.not_to change { image.type } }
       it { expect { call }.not_to change { image.size } }
+      it { expect(call).to be_falsy }
 
     end
-    
     
     context 'partial image with enough data' do
 
@@ -71,6 +71,7 @@ describe ImageInfo::Parser do
 
       it { expect { call }.to change { image.type }.to eq(:jpeg) }
       it { expect { call }.to change { image.size }.to eq([775, 525]) }
+      it { expect(call).to be_truthy }
 
     end
 


### PR DESCRIPTION
This PR streams requests from typhoeus and abort them as soon as enough data as been downloaded to get the type and size of image. Solves #1 

The speed improvement is huge for large image or connection to slow hosts :

Before :

```
2.2.2 :003 > puts Benchmark.measure { ImageInfo.from("http://imgsv.imaging.nikon.com/lineup/dslr/d600/img/sample01/img_04_l.jpg") }
  1.520000   0.550000   2.070000 (122.197889)
```

After :

```
2.2.2 :005 > puts Benchmark.measure { ImageInfo.from("http://imgsv.imaging.nikon.com/lineup/dslr/d600/img/sample01/img_04_l.jpg") }
  0.060000   0.020000   0.080000 ( 2.359798)
```

But when downloading lots of small images there isn't any real difference. Ex: find size for all images of [unimpressedcats](http://unimpressedcats.tumblr.com/)

Before :

```
2.2.2 :003 > puts Benchmark.measure { ImageInfo.from(["http://hit-counter.info/hit.php?id=614340&counter=11", "http://i50.tinypic.com/oft2ky.gif","http://41.media.tumblr.com/80d7139b2fef7f415b89836679a69ea7/tumblr_nrsc81iHo71ri5cmio1_500.jpg", "http://36.media.tumblr.com/60db7d23c38fc2e5ca23935c00518d13/tumblr_nlms7jr0Ca1qi17eeo1_500.jpg", "http://40.media.tumblr.com/013f06f3e3f44ac1fc6ebc50f8750393/tumblr_n7f6usGHGX1tqbr7ro1_500.jpg"]) }
  0.020000   0.010000   0.030000 (  0.426701)
```

After :

```
2.2.2 :005 > puts Benchmark.measure { ImageInfo.from(["http://hit-counter.info/hit.php?id=614340&counter=11", "http://i50.tinypic.com/oft2ky.gif","http://41.media.tumblr.com/80d7139b2fef7f415b89836679a69ea7/tumblr_nrsc81iHo71ri5cmio1_500.jpg", "http://36.media.tumblr.com/60db7d23c38fc2e5ca23935c00518d13/tumblr_nlms7jr0Ca1qi17eeo1_500.jpg", "http://40.media.tumblr.com/013f06f3e3f44ac1fc6ebc50f8750393/tumblr_n7f6usGHGX1tqbr7ro1_500.jpg"]) }
  0.020000   0.010000   0.030000 (  0.416174)
```
