### PR TITLE
Prevent code break when image is defective

### DIFF
--- a/lib/image_info/request_handler.rb
+++ b/lib/image_info/request_handler.rb
@@ -21,6 +21,8 @@ module ImageInfo
 
     def found_image_info?(chunk)
       ::ImageInfo::Parser.new(image, chunk).call
+    rescue
+      false
     end
   end
 end


### PR DESCRIPTION
I came across a weird problem when using this gem through the [link_thumbnailer](https://github.com/gottfrois/link_thumbnailer).

To reproduce the problem, try this out on the console:

```ruby
image = ::ImageInfo::Image.new('https://s0.wp.com/i/blank.jpg')
build = ImageInfo::RequestHandler.new(image).build
build.run
```

The image `blank.jpg` exists and is used as the og:image of [this url](https://codeascraft.com/2016/10/19/being-an-effective-ally-to-women-and-non-binary-people/). 

When the code tries to evaluate the size of the image, the code breaks. It happens inside the [image_size](https://github.com/toy/image_size) gem, exactly [on this line](https://github.com/toy/image_size/blob/master/lib/image_size.rb#L150) because `length` is (oddly enough) null.

To prevent the `image_info` gem to break due to problems outside its context, I came to propose this `rescue` fallback on the `found_image_info?` method, inside the `lib/image_info/request_handler.rb` file.
