### PR TITLE
Stop setting URI port when it doesn't have specified it

### DIFF
--- a/lib/image_info/image.rb
+++ b/lib/image_info/image.rb
@@ -8,7 +8,6 @@ module ImageInfo
     def initialize(uri)
       @uri        = ::Addressable::URI.parse(uri.to_s)
       @uri.scheme = 'http'  unless @uri.scheme
-      @uri.port   = 80      unless @uri.port
       @uri.normalize!
     rescue ::Addressable::URI::InvalidURIError
       @uri = NullUri.new

--- a/lib/image_info/image.rb
+++ b/lib/image_info/image.rb
@@ -7,7 +7,7 @@ module ImageInfo
 
     def initialize(uri)
       @uri        = ::Addressable::URI.parse(uri.to_s)
-      @uri.scheme = 'http'  unless @uri.scheme
+      @uri.scheme = 'http' unless @uri.scheme
       @uri.normalize!
     rescue ::Addressable::URI::InvalidURIError
       @uri = NullUri.new


### PR DESCRIPTION
Fix #9 

I suppose setting the URI port manually is not needed even though it doesn't have specified it because:

- We set the URI scheme when it doesn't have specified it, it means we can learn the URI's port must be `80` at this point
- If we explicitly specify a URI port it results in the wrong URI might be generated later like: `https://github.com:80/` 
  - See https://github.com/gottfrois/image_info/commit/a781365c1dc8da0600887a605ba556b8a431fef2#r42932189 for detail